### PR TITLE
add schedule for release with github actions

### DIFF
--- a/.github/workflows/autocheck.sh
+++ b/.github/workflows/autocheck.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+git config --local user.email "action@github.com"
+git config --local user.name "GitHub Action"
+
+function compare_version() {
+    test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"
+}
+
+RELEASE_TAG=$(curl -s https://raw.githubusercontent.com/winw1010/tataru-assistant/main/package.json | jq -r .version)
+PUBLISHED_TAG=$(curl -s https://api.github.com/repos/winw1010/tataru-assistant/releases | jq -r '.[] | .tag_name' | head -n 1|sed 's/v//g')
+
+echo "上游版本: ${RELEASE_TAG}"
+echo "发布版本: ${PUBLISHED_TAG}"
+
+if [ "${PUBLISHED_TAG}" == "" ] || compare_version ${RELEASE_TAG} ${PUBLISHED_TAG}
+then
+   echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+   echo "status=ready" >> $GITHUB_OUTPUT
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 */2 * * *'
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build and deploy Tataru Assistant
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *'
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Execute version check script
+        id: auto-check
+        run: bash .github/workflows/autocheck.sh
+
+      - name: Build and package
+        if: steps.auto-check.outputs.status == 'ready'
+        run: |
+          npm install
+          npm run dist
+          npx electron-builder --win --x64
+
+      - name: Create release
+        id: create_release
+        if: steps.auto-check.outputs.status == 'ready'
+        uses: comnoco/create-release-action@v2
+        env:
+          RELEASE_VERSION: ${{ steps.auto-check.outputs.release_tag }}
+        with:
+          tag_name: v${{ env.RELEASE_VERSION }}
+          release_name: Release v${{ env.RELEASE_VERSION }}
+
+      - name: Upload artifact
+        if: steps.auto-check.outputs.status == 'ready'
+        uses: actions/upload-release-asset@v1
+        env:
+          RELEASE_VERSION: ${{ steps.auto-check.outputs.release_tag }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/Tataru Assistant Setup ${{ steps.auto-check.outputs.release_tag }}.exe
+          asset_name: Tataru_Assistant_Setup.exe
+          asset_content_type: application/octet-stream
+
+  del_runs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 0
+          keep_minimum_runs: 6

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - [原始碼使用說明](https://github.com/winw1010/tataru-assistant/blob/main/doc/README_SOURCE.md)
 
-- [下載 Tataru Assistant](https://drive.google.com/drive/folders/14zjoUNzZTKgn2mCiAx6YJ14-fsd8M_I_?usp=drive_link)
+- [下載 Tataru Assistant](https://github.com/winw1010/tataru-assistant/releases/latest/download/Tataru_Assistant_Setup.exe)
 
 ## 安裝步驟
 

--- a/src/html/util/index.js
+++ b/src/html/util/index.js
@@ -232,7 +232,7 @@ function setButton() {
 
   // update
   document.getElementById('img-button-update').onclick = () => {
-    ipcRenderer.send('execute-command', 'explorer "https://home.gamer.com.tw/artwork.php?sn=5323128"');
+    ipcRenderer.send('execute-command', 'explorer "https://github.com/winw1010/tataru-assistant/releases/latest/download/Tataru_Assistant_Setup.exe"');
   };
 
   // minimize


### PR DESCRIPTION
*通过github action编译发布程序
*每两个小时检查一次
*将升级安装包地址修改为最新release地址方便升级
*保留最近6个workflow记录
因为应用版本检查使用的是https://raw.githubusercontent.com/winw1010/tataru-assistant-text/main/version.json ，而github action是通过本仓库的package.json来做版本检查，不知道有什么区别，管理自己可以修改下