### PR TITLE
[Feature] add second translator option

### DIFF
--- a/src/html/config.html
+++ b/src/html/config.html
@@ -336,6 +336,18 @@
 
         <br />
 
+        <!-- select translator-second -->
+        <div class="row align-items-center">
+          <div class="col">
+            <label for="select-engine-second"></label>
+          </div>
+          <div class="col-6">
+            <select class="form-select" id="select-engine-second"></select>
+          </div>
+        </div>
+
+        <br />
+
         <!-- select from -->
         <div class="row align-items-center">
           <div class="col">

--- a/src/html/config.js
+++ b/src/html/config.js
@@ -33,6 +33,8 @@ function setIPC() {
 async function setView() {
   document.getElementById('select-engine').innerHTML = await ipcRenderer.invoke('get-engine-select');
 
+  document.getElementById('select-engine-second').innerHTML = await ipcRenderer.invoke('get-engine-select-second');
+
   document.getElementById('select-from').innerHTML = await ipcRenderer.invoke('get-source-select');
 
   document.getElementById('select-from-player').innerHTML = await ipcRenderer.invoke('get-player-source-select');
@@ -433,6 +435,12 @@ function saveOptions(config = {}) {
       }
     }
   });
+
+  // check primary same second
+  if (config.translation.engine == config.translation.engineSecond) {
+    config.translation.engineSecond = 'Auto'
+    ipcRenderer.send('add-notification', 'CHECK_SECOND_TRANSLATOR');
+  }
 }
 
 function getOptionList() {
@@ -569,6 +577,10 @@ function getOptionList() {
     [
       ['select-engine', 'value'],
       ['translation', 'engine'],
+    ],
+    [
+      ['select-engine-second', 'value'],
+      ['translation', 'engineSecond'],
     ],
     [
       ['select-from', 'value'],

--- a/src/html/dictionary.js
+++ b/src/html/dictionary.js
@@ -37,10 +37,14 @@ async function setView() {
   const config = await ipcRenderer.invoke('get-config');
 
   document.getElementById('select-engine').innerHTML = await ipcRenderer.invoke('get-engine-select');
+  document.getElementById('select-engine-second').innerHTML = await ipcRenderer.invoke('get-engine-select-second');
+
   document.getElementById('select-from').innerHTML = await ipcRenderer.invoke('get-all-language-select');
   document.getElementById('select-to').innerHTML = await ipcRenderer.invoke('get-all-language-select');
 
   document.getElementById('select-engine').value = config.translation.engine;
+  document.getElementById('select-engine-second').value = config.translation.engineSecond;
+
   document.getElementById('select-from').value = config.translation.from;
   document.getElementById('select-to').value = config.translation.to;
 
@@ -116,6 +120,8 @@ async function createDialogData(name = '', text = '') {
   dialogData.translation.fromPlayer = document.getElementById('select-from').value;
   dialogData.translation.to = document.getElementById('select-to').value;
   dialogData.translation.engine = document.getElementById('select-engine').value;
+  dialogData.translation.engineSecond = document.getElementById('select-engine-second').value;
+
   dialogData.translation.autoChange = false;
 
   return dialogData;

--- a/src/html/edit.js
+++ b/src/html/edit.js
@@ -36,10 +36,14 @@ async function setView() {
   const config = await ipcRenderer.invoke('get-config');
 
   document.getElementById('select-engine').innerHTML = await ipcRenderer.invoke('get-engine-select');
+  document.getElementById('select-engine-second').innerHTML = await ipcRenderer.invoke('get-engine-select-second');
+
   document.getElementById('select-from').innerHTML = await ipcRenderer.invoke('get-source-select');
   document.getElementById('select-to').innerHTML = await ipcRenderer.invoke('get-target-select');
 
   document.getElementById('select-engine').value = config.translation.engine;
+  document.getElementById('select-engine-second').value = config.translation.engineSecond;
+
   document.getElementById('select-from').value = config.translation.from;
   document.getElementById('select-to').value = config.translation.to;
 
@@ -85,6 +89,8 @@ function setButton() {
     }
 
     dialogData.translation.engine = document.getElementById('select-engine').value;
+    dialogData.translation.engineSecond = document.getElementById('select-engine-second').value;
+
     dialogData.translation.from = document.getElementById('select-from').value;
     dialogData.translation.fromPlayer = document.getElementById('select-from').value;
     dialogData.translation.to = document.getElementById('select-to').value;

--- a/src/html/js/language.js
+++ b/src/html/js/language.js
@@ -170,6 +170,7 @@ function getElementTextList() {
         'checkbox-skip-system': ['忽略常見系統訊息', '忽略常见系统讯息', 'Ignore System Message'],
         'checkbox-skip-chinese': ['不翻譯漢化字幕', '不翻译汉化字幕', "Don't translate Chinese text"],
         'select-engine': ['翻譯器', '翻译器', 'Translator'],
+        'select-engine-second': ['優先備用', '优先备用', 'Translator of second'],
         'select-from': ['遊戲語言', '游戏语言', 'Game Language'],
         'select-from-player': ['隊伍語言', '队伍语言', 'Party Language'],
         'select-to': ['目標語言', '目标语言', 'Target Language'],

--- a/src/module/system/config-module.js
+++ b/src/module/system/config-module.js
@@ -62,6 +62,7 @@ const defaultConfig = {
     skipChinese: true,
     replace: true,
     engine: 'Youdao',
+    engineSecond: 'Auto',
     from: 'Japanese',
     fromPlayer: 'Auto',
     to: 'Traditional-Chinese',

--- a/src/module/system/engine-module.js
+++ b/src/module/system/engine-module.js
@@ -167,6 +167,10 @@ function getEngineSelect() {
   return getSelect(engineList);
 }
 
+function getEngineSelectSecond() {
+  return getSelectSecond(engineList);
+}
+
 // get all language select
 function getAllLanguageSelect() {
   return getSelect(allLanguageList);
@@ -204,6 +208,13 @@ function getSelect(list = []) {
       innerHTML += `<option value="${name}"></option>`;
     }
   }
+
+  return innerHTML;
+}
+
+function getSelectSecond(list = []) {
+  let innerHTML = `<option value="Auto"></option>`;
+  innerHTML += getEngineSelect();
 
   return innerHTML;
 }
@@ -264,6 +275,7 @@ module.exports = {
   languageIndex,
 
   getEngineSelect,
+  getEngineSelectSecond,
   getAllLanguageSelect,
   getSourceSelect,
   getPlayerSourceSelect,

--- a/src/module/system/ipc-module.js
+++ b/src/module/system/ipc-module.js
@@ -524,6 +524,10 @@ function setTranslateChannel() {
     return engineModule.getEngineSelect();
   });
 
+  ipcMain.handle('get-engine-select-second', () => {
+    return engineModule.getEngineSelectSecond();
+  });
+
   // get all language select
   ipcMain.handle('get-all-language-select', () => {
     return engineModule.getAllLanguageSelect();

--- a/src/module/system/notification-module.js
+++ b/src/module/system/notification-module.js
@@ -19,6 +19,7 @@ const message = {
   TEMP_DELETED: ['暫存清除完畢', '暂存清除完毕', 'Temp file deleted'],
 
   SETTINGS_SAVED: ['設定已儲存', '设定已储存', 'Settings saved'],
+  CHECK_SECOND_TRANSLATOR: ['優選備用不可與首選一緻，已重置。','优选备用不可与首选一致，已重置。','The Second translator cannot be the same as the primary choice. It has been reset.'],
   RESTORED_TO_DEFAULT_SETTINGS: ['已恢復預設值', '已恢復预设值', 'Restored to default settings'],
 
   GOOGLE_CREDENTIAL_SAVED: ['已儲存Google憑證', '已储存Google凭证', 'Google credential saved'],

--- a/src/module/system/translate-module.js
+++ b/src/module/system/translate-module.js
@@ -55,7 +55,7 @@ async function translate2(text = '', translation = {}, type = 'sentence') {
   
   // If engineSecond is not in engineList, it indicates that it is an AI-based translator. In that case, add engineSecond to the list. 
   // Even if engineSecond causes an error due to misconfiguration, it will not affect the normal operation of the program.
-  if (engineList.indexOf(translation.engineSecond) < 0) {
+  if (engineList.indexOf(translation.engineSecond) < 0 && translation.engineSecond != 'Auto') {
     engineList.push(translation.engineSecond)
   }
 

--- a/src/module/system/translate-module.js
+++ b/src/module/system/translate-module.js
@@ -53,9 +53,10 @@ async function translate2(text = '', translation = {}, type = 'sentence') {
   let result = { isError: false, text: '' };
   let engine = ''
   
-  // Since engineList does not include 'LLM-API', it needs to be added if the user's alternative option is LLM-API. 
-  if (translation.engineSecond == 'LLM-API') {
-    engineList.push('LLM-API')
+  // If engineSecond is not in engineList, it indicates that it is an AI-based translator. In that case, add engineSecond to the list. 
+  // Even if engineSecond causes an error due to misconfiguration, it will not affect the normal operation of the program.
+  if (engineList.indexOf(translation.engineSecond) < 0) {
+    engineList.push(translation.engineSecond)
   }
 
   do {

--- a/src/module/system/translate-module.js
+++ b/src/module/system/translate-module.js
@@ -51,9 +51,22 @@ async function translate2(text = '', translation = {}, type = 'sentence') {
   const autoChange = translation.autoChange;
   let engineList = engineModule.getEngineList(translation.engine);
   let result = { isError: false, text: '' };
+  let engine = ''
+  
+  // Since engineList does not include 'LLM-API', it needs to be added if the user's alternative option is LLM-API. 
+  if (translation.engineSecond == 'LLM-API') {
+    engineList.push('LLM-API')
+  }
 
   do {
-    const engine = engineList.shift();
+    // When result.isError is true and translation.engineSecond is not 'Auto' 
+    // we also need to check whether the remaining contents of engineList include engineSecond.
+    if (result.isError && translation.engineSecond != 'Auto' && engineList.indexOf(translation.engineSecond) > 0) {
+      engine = translation.engineSecond
+      engineList.splice(engineList.indexOf(translation.engineSecond), 1)
+    } else {
+      engine = engineList.shift();
+    }
     const option = engineModule.getTranslateOption(engine, translation.from, translation.to, text);
 
     console.log('\r\nEngine:', engine);


### PR DESCRIPTION
增加了一个优选备用翻译器选项。

场景如下
1. 国内网络
2. 使用 2 款 AI 翻译
3. 当第一款 AI 翻译网络出错时，原始逻辑是会修改到 Youdao，但 Youdao 的翻译质量非常差。
————

实际情况
1. 国内网络
2. 我使用 GEMINI 和 DEEPSEEK
3. 由于 DEEPSEEK 的网络请求实在是太慢了，并没有 GEMINI 快，所以我主要是使用 GEMINi，但有时候 GEMINI 会出现 TLS 或 10000MS 超时的情况，这时候会自动切到 Youdao ，我不太喜欢 Youdao 的翻译结果，比较差。
—————

大概是如此，所以我看了一下源代码做出了对应的功能。

功能逻辑如下

1. 默认为 Auto 模式，Auto 模式下和程序原逻辑无差别。
2. 当修改了备选时，当第一次翻译器出错后会走备选逻辑。
3. AI-engine 并不在 `engineList` 这个数组里，所以当用户选择了 AI-engine 会在数组里添加进去
4. 在保存配置时会判断 主 翻译器 和 备选翻译器是否为同一个 ，如果是同一个则会重置为 Auto 并提示用户，相关可参考 `config.js` 修改
5. 主要判断备选的逻辑代码就 1 行 ` if (result.isError && translation.engineSecond != 'Auto' && engineList.indexOf(translation.engineSecond) > 0) {` 是否为错误，且不等于 Auto，并且备选存在于 `engineList` 未使用的翻译器数组里

嗯…太久没写代码可能写的不太好，但尽可能的保持了项目的编码风格。

最后谢谢作者提供的软件。
